### PR TITLE
Correct command to call jar as -jar instead of -cp

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@ A project to create a stub/mock environment for testing ExecuteScript processors
 
 ## Usage
 
-java -cp nifi-script-tester-<version>-all.jar [options] script_file
+```
+java -jar nifi-script-tester-<version>-all.jar [options] script_file
+```
 
   Where options may include:
   


### PR DESCRIPTION
As referenced in the related blog article, https://funnifi.blogspot.com/2016/06/testing-executescript-processor-scripts.html, correct the command to call the built jar file using -jar instead of -cp