### PR TITLE
Parse processor properties

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     compile "org.apache.nifi:nifi-api:${project.ext.NIFI_VERSION}"
     compile "org.apache.nifi:nifi-mock:${project.ext.NIFI_VERSION}"
     compile 'commons-io:commons-io:2.5'
+    compile 'info.picocli:picocli:3.5.0'
     testCompile 'junit:junit:4.12'
     runtime 'junit:junit:4.12'
     runtime 'org.slf4j:slf4j-log4j12:1.7.14'

--- a/src/main/java/nifi/ScriptRunner.java
+++ b/src/main/java/nifi/ScriptRunner.java
@@ -140,14 +140,7 @@ public class ScriptRunner {
                 System.err.println("Attribute file does not exist: " + options.attrFile);
                 System.exit(5);
             } else {
-                try {
-                    Properties p = new Properties();
-                    p.load(Files.newBufferedReader(attrFilePath));
-                    p.forEach((k, v) -> incomingAttributes.put(k.toString(), v.toString()));
-                } catch (IOException ioe) {
-                    System.err.println("Could not read properties file: " + options.attrFile + ", reason: " + ioe.getLocalizedMessage());
-                    System.exit(5);
-                }
+                loadProperties(attrFilePath).forEach((k, v) -> incomingAttributes.put(k.toString(), v.toString()));
             }
         }
 
@@ -199,6 +192,17 @@ public class ScriptRunner {
         if (options.outputFailure) {
             outputFlowFilesForRelationship(ExecuteScript.REL_FAILURE, options);
         }
+    }
+
+    private static Properties loadProperties(Path path) {
+        Properties props = new Properties();
+        try {
+            props.load(Files.newBufferedReader(path));
+        } catch (IOException e) {
+            System.err.println(String.format("Could not read properties file: %s, reason: %s",path, e.getLocalizedMessage()));
+            System.exit(5);
+        }
+        return props;
     }
 
     private static Options parseCommandLine(String[] args) {

--- a/src/test/java/nifi/ScriptRunnerTest.java
+++ b/src/test/java/nifi/ScriptRunnerTest.java
@@ -93,4 +93,11 @@ public class ScriptRunnerTest {
         System.setIn(bais);
         ScriptRunner.main(new String[]{"-all", "-attrfile=src/test/resources/attrfiles/incoming_attributes.properties", "src/test/resources/test_attributes_to_propfile.groovy"});
     }
+
+    @Test
+    public void testWithProperties() throws Exception {
+        ByteArrayInputStream bais = new ByteArrayInputStream("Hello World!".getBytes());
+        System.setIn(bais);
+        ScriptRunner.main(new String[]{"-all", "-properties=src/test/resources/properties/simple.properties", "src/test/resources/test_processor_properties.groovy"});
+    }
 }

--- a/src/test/java/nifi/ScriptRunnerTest.java
+++ b/src/test/java/nifi/ScriptRunnerTest.java
@@ -59,7 +59,7 @@ public class ScriptRunnerTest {
 
     @Test
     public void testRouteToFailure() throws Exception {
-        ScriptRunner.main(new String[]{"-failure -no-success", "src/test/resources/test_route_to_fail.groovy"});
+        ScriptRunner.main(new String[]{"-failure","-no-success", "src/test/resources/test_route_to_fail.groovy"});
     }
 
     @Test

--- a/src/test/resources/properties/simple.properties
+++ b/src/test/resources/properties/simple.properties
@@ -1,0 +1,1 @@
+processorproperty=Passing Test

--- a/src/test/resources/test_processor_properties.groovy
+++ b/src/test/resources/test_processor_properties.groovy
@@ -1,0 +1,10 @@
+import org.apache.nifi.processor.io.OutputStreamCallback
+
+flowFile = session.get()
+if(!flowFile) return
+session.write(flowFile, {output ->
+    output.withPrintWriter { o ->
+        o.println(processorproperty)
+    }
+} as OutputStreamCallback)
+session.transfer(flowFile, REL_SUCCESS)


### PR DESCRIPTION
Hi Matt. Thank you for this tool!

I needed to be able to pass processor properties to one of the scripted processors I am working on.

This patch does two things:
1. It makes use of a library, [picocli](https://picocli.info/), to parse command-line input. I did this to simplify any future additions to the cli.
2. It adds a cli option, `-properties` that, like `-attrs`, specifies a path to a properties file. The contents of this file are mapped to the processor properties.

I also tried to consolidate input validation tasks to one place.

Please let me know what I can do to make this a palatable contribution for your project.